### PR TITLE
Excluded `org.pentaho.pentaho-aggdesigner-algorithm` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [TBD] - TBD
+### Changed
+- Excluded `org.pentaho.pentaho-aggdesigner-algorithm` dependency as it's not available in Maven Central.
+
 ## [1.0.0] - 2019-03-13
 ### Added
 - Initial release.

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
       <groupId>com.klarna</groupId>
       <artifactId>hiverunner</artifactId>
       <version>4.1.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.pentaho</groupId>
+          <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>


### PR DESCRIPTION
This dependency isn't available in Maven Central and means you can't build the project if you don't have a settings.xml file (i.e. Maven defaults).