### PR TITLE
Excluded `javax.jms.jms` dependency as it's not available in Maven Central

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [TBD] - TBD
 ### Changed
 - Excluded `org.pentaho.pentaho-aggdesigner-algorithm` dependency as it's not available in Maven Central.
+- Excluded `javax.jms.jms` dependency as it's not available in Maven Central.
 
 ## [1.0.0] - 2019-03-13
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,10 @@
           <groupId>org.pentaho</groupId>
           <artifactId>pentaho-aggdesigner-algorithm</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>javax.jms</groupId>
+          <artifactId>jms</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
See https://issues.sonatype.org/browse/MVNCENTRAL-348 for why. 